### PR TITLE
Fix #1

### DIFF
--- a/src/VASAutoBalance.cpp
+++ b/src/VASAutoBalance.cpp
@@ -494,7 +494,8 @@ public:
 		creature->CustomData.Set("VAS_AutoBalanceCreatureInfo", new AutoBalanceCreatureInfo(instancePlayerCount, damageMultiplier));
 
 		creature->UpdateAllStats();
-    	creature->SetFullHealth();
+        if (creature->GetHealth() > 0)
+    	    creature->SetFullHealth();
 	}
 };
 class VAS_AutoBalance_CommandScript : public CommandScript


### PR DESCRIPTION
This will fix the dead creatures showing max health when entered a different area.