### PR TITLE
fix typo in config

### DIFF
--- a/conf/VASAutoBalance.conf.dist
+++ b/conf/VASAutoBalance.conf.dist
@@ -151,11 +151,11 @@ VASAutoBalance.ForcedID5="8317,15203,15204,15205,15305,6109,26801,30508,26799,30
 VASAutoBalance.ForcedID2=""
 
 #
-#     VASAutoBalance.DisableID
+#     VASAutoBalance.DisabledID
 #        Disable scaling on specific creatures
 #
 
-VASAutoBalance.DisableID=""
+VASAutoBalance.DisabledID=""
 
 ##########################
 #


### PR DESCRIPTION
There was a typo in the config: "VASAutoBalance.DisableID" instead of "VASAutoBalance.DisabledID".
See the appropriate line in the code:
https://github.com/azerothcore/mod-vas-autobalance/blob/6327f3fe824095df43cae824311724acfe1cd1aa/src/VASAutoBalance.cpp#L208