### PR TITLE
feat(CI): improve Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,67 +16,21 @@ services:
 git:
   depth: 1
 
-matrix:
-  include:
-    - os: linux
-      addons:
-        apt:
-          packages:
-            - clang-3.8
-      env:
-        - CCOMPILERC="clang-3.8"
-        - CCOMPILERCXX="clang++-3.8"
-
-    - os: linux
-      addons:
-        apt:
-          sources:
-            - llvm-toolchain-xenial-7
-          packages:
-            - clang-7
-      env:
-        - CCOMPILERC="clang-7"
-        - CCOMPILERCXX="clang++-7"
+env:
+  - TRAVIS_BUILD_ID="1"
+  - TRAVIS_BUILD_ID="2"
 
 before_install:
   - git config user.email "travis@build.bot" && git config user.name "Travis CI"
   - git tag -a -m "Travis build" init
-
-install:
   - cd ..
   - git clone --depth=1 --branch=master https://github.com/azerothcore/azerothcore-wotlk.git azerothcore-wotlk
   - mv mod-vas-autobalance azerothcore-wotlk/modules
   - cd azerothcore-wotlk
+  - source ./apps/ci/ci-before_install.sh
 
-  # install OS deps (apt-get)
-  - bash ./acore.sh "install-deps"
-  # create config file
-  - echo "CCOMPILERC=$CCOMPILERC" >> conf/config.sh
-  - echo "CCOMPILERCXX=$CCOMPILERCXX" >> conf/config.sh
-  - echo "MTHREADS=4" >> conf/config.sh
-  - echo "CWARNINGS=ON" >> conf/config.sh
-  - echo "CDEBUG=OFF" >> conf/config.sh
-  - echo "CTYPE=Release" >> conf/config.sh
-  - echo "CSCRIPTS=ON" >> conf/config.sh
-  - echo "CSERVERS=ON" >> conf/config.sh
-  - echo "CTOOLS=ON" >> conf/config.sh
-  - echo "CSCRIPTPCH=OFF" >> conf/config.sh
-  - echo "CCOREPCH=OFF" >> conf/config.sh
-  - echo "CCUSTOMOPTIONS='-DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_C_FLAGS=\"-Werror\" -DCMAKE_CXX_FLAGS=\"-Werror\"'" >> conf/config.sh
-  - echo "DB_CHARACTERS_CONF=\"MYSQL_USER='root'; MYSQL_PASS=''; MYSQL_HOST='127.0.0.1';\"" >> conf/config.sh
-  - echo "DB_AUTH_CONF=\"MYSQL_USER='root'; MYSQL_PASS=''; MYSQL_HOST='127.0.0.1';\"" >> conf/config.sh
-  - echo "DB_WORLD_CONF=\"MYSQL_USER='root'; MYSQL_PASS=''; MYSQL_HOST='127.0.0.1';\"" >> conf/config.sh  
-  # create and import mysql
-  - mysql -e "SET GLOBAL sql_mode = '';" # this is necessary because of mysql 5.7
-  - bash ./acore.sh "db-assembler" "import-all"
+install:
+  - source ./apps/ci/ci-install.sh
 
 script:
-  # compile
-  - export CCACHE_CPP2=true
-  - ccache -s
-  - timeout 2580 bash ./acore.sh "compiler" "all"
-  - ccache -s
-  - git clone --depth=1 --branch=master --single-branch https://github.com/ac-data/ac-data.git /home/travis/build/azerothcore/azerothcore-wotlk/env/dist/data
-  - cp ./data/travis/worldserver.conf ./env/dist/etc/worldserver.conf
-  - ./env/dist/bin/worldserver --dry-run
-  - ./apps/ci-error-check.sh
+  - source ./apps/ci/ci-script.sh


### PR DESCRIPTION
- use random DB names in order to detect statements which address a specific DB
- split compilation and DB check (DB check and dry run only have to run once)
- use separate shell scripts for easier module Travis integration
- update to the Travis configuration will now only be necessary if the OS for the Travis check changes

see https://github.com/azerothcore/azerothcore-wotlk/pull/1486