### PR TITLE
Fix creatures not scaling based on LFG information 

### DIFF
--- a/src/ABAllCreatureScript.cpp
+++ b/src/ABAllCreatureScript.cpp
@@ -298,7 +298,7 @@ bool AutoBalance_AllCreatureScript::ResetCreatureIfNeeded(Creature* creature)
         return false;
 
     // get (or create) map and creature info
-    AutoBalanceMapInfo* mapABInfo = creature->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(creature->GetMap());
     AutoBalanceCreatureInfo* creatureABInfo = creature->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo");
 
     // if creature is dead and mapConfigTime is 0, skip for now
@@ -421,7 +421,7 @@ void AutoBalance_AllCreatureScript::ModifyCreatureAttributes(Creature* creature)
     AutoBalanceCreatureInfo* creatureABInfo = creature->CustomData.GetDefault<AutoBalanceCreatureInfo>("AutoBalanceCreatureInfo");
     Map* map = creature->GetMap();
     InstanceMap* instanceMap = map->ToInstanceMap();
-    AutoBalanceMapInfo* mapABInfo = instanceMap->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(instanceMap);
 
     // mark the creature as updated using the current settings if needed
     // if this creature is brand new, do not update this so that it will be re-processed next OnCreatureUpdate

--- a/src/ABAllMapScript.h
+++ b/src/ABAllMapScript.h
@@ -12,14 +12,12 @@ class AutoBalance_AllMapScript : public AllMapScript
 public:
     AutoBalance_AllMapScript()
         : AllMapScript("AutoBalance_AllMapScript", {
-            ALLMAPHOOK_ON_CREATE_MAP,
             ALLMAPHOOK_ON_PLAYER_ENTER_ALL,
             ALLMAPHOOK_ON_PLAYER_LEAVE_ALL
         })
     {
     }
 
-    void OnCreateMap(Map* map) override;
     // hook triggers after the player has already entered the world
     void OnPlayerEnterAll(Map* map, Player* player) override;
     // hook triggers just before the player left the world

--- a/src/ABCommandScript.cpp
+++ b/src/ABCommandScript.cpp
@@ -42,7 +42,7 @@ bool AutoBalance_CommandScript::HandleABMapStatsCommand(ChatHandler* handler, co
     Player* player = handler->GetPlayer();
     auto locale = handler->GetSession()->GetSessionDbLocaleIndex();
 
-    AutoBalanceMapInfo* mapABInfo = player->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(player->GetMap());
 
     if (player->GetMap()->IsDungeon())
     {

--- a/src/ABGameObjectScript.cpp
+++ b/src/ABGameObjectScript.cpp
@@ -2,6 +2,7 @@
 
 #include "ABConfig.h"
 #include "ABMapInfo.h"
+#include "ABUtils.h"
 
 void AutoBalance_GameObjectScript::OnGameObjectModifyHealth(GameObject* target, Unit* source, int32& amount, SpellInfo const* spellInfo)
 {
@@ -135,7 +136,7 @@ int32 AutoBalance_GameObjectScript::_Modify_GameObject_Damage_Healing(GameObject
     }
 
     // get the map's info
-    AutoBalanceMapInfo* targetMapABInfo = target->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* targetMapABInfo = GetMapInfo(target->GetMap());
 
     // if the target's map is not enabled, return the original damage
     if (!targetMapABInfo->enabled)

--- a/src/ABGlobalScript.cpp
+++ b/src/ABGlobalScript.cpp
@@ -2,6 +2,7 @@
 
 #include "ABConfig.h"
 #include "ABMapInfo.h"
+#include "ABUtils.h"
 
 void AutoBalance_GlobalScript::OnAfterUpdateEncounterState(Map* map, EncounterCreditType type, uint32 /*creditEntry*/, Unit* /*source*/, Difficulty /*difficulty_fixed*/, DungeonEncounterList const* /*encounters*/, uint32 /*dungeonCompleted*/, bool updated)
 {
@@ -11,7 +12,7 @@ void AutoBalance_GlobalScript::OnAfterUpdateEncounterState(Map* map, EncounterCr
     if (!rewardEnabled || !updated)
         return;
 
-    AutoBalanceMapInfo* mapABInfo = map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(map);
 
     if (mapABInfo->adjustedPlayerCount < MinPlayerReward)
         return;

--- a/src/ABMapInfo.h
+++ b/src/ABMapInfo.h
@@ -57,6 +57,6 @@ public:
     uint8    levelScalingDynamicFloor           = 0;     // How many levels LESS than the highestPlayerLevel creature should be scaled to
 
     uint8    prevMapLevel                       = 0;     // Used to reduce calculations when they are not necessary
+    bool     initialized                        = false; // Whether or not the map has been initialized
 };
-
 #endif

--- a/src/ABPlayerScript.cpp
+++ b/src/ABPlayerScript.cpp
@@ -32,7 +32,7 @@ void AutoBalance_PlayerScript::OnPlayerLevelChanged(Player* player, uint8 oldlev
     UpdateMapPlayerStats(map);
 
     // schedule all creatures for an update
-    AutoBalanceMapInfo* mapABInfo = map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(map);
     mapABInfo->mapConfigTime = GetCurrentConfigTime();
 }
 
@@ -44,7 +44,7 @@ void AutoBalance_PlayerScript::OnPlayerGiveXP(Player* player, uint32& amount, Un
     if (!map->IsDungeon() || !map->GetInstanceId() || !victim)
         return;
 
-    AutoBalanceMapInfo* mapABInfo = map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(map);
 
     if (victim && RewardScalingXP && mapABInfo->enabled)
     {
@@ -81,7 +81,7 @@ void AutoBalance_PlayerScript::OnPlayerBeforeLootMoney(Player* player, Loot* loo
     if (!map->IsDungeon())
         return;
 
-    AutoBalanceMapInfo* mapABInfo = map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(map);
     ObjectGuid sourceGuid = loot->sourceWorldObjectGUID;
 
     if (mapABInfo->enabled && RewardScalingMoney)
@@ -136,7 +136,7 @@ void AutoBalance_PlayerScript::OnPlayerEnterCombat(Player* player, Unit* /*enemy
 
     LOG_DEBUG("module.AutoBalance_CombatLocking", "AutoBalance_PlayerScript::OnPlayerEnterCombat: {} enters combat.", player->GetName());
 
-    AutoBalanceMapInfo* mapABInfo = map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(map);
 
     // if this map isn't enabled, no work to do
     if (!mapABInfo->enabled)
@@ -175,7 +175,7 @@ void AutoBalance_PlayerScript::OnPlayerLeaveCombat(Player* player)
     // unfortunately, `player->IsInCombat()` doesn't work here
     LOG_DEBUG("module.AutoBalance_CombatLocking", "AutoBalance_PlayerScript::OnPlayerLeaveCombat: {} leaves (or wasn't in) combat.", player->GetName());
 
-    AutoBalanceMapInfo* mapABInfo = map->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* mapABInfo = GetMapInfo(map);
 
     // if this map isn't enabled, no work to do
     if (!mapABInfo->enabled)

--- a/src/ABUnitScript.cpp
+++ b/src/ABUnitScript.cpp
@@ -3,6 +3,7 @@
 #include "ABConfig.h"
 #include "ABCreatureInfo.h"
 #include "ABMapInfo.h"
+#include "ABUtils.h"
 
 void AutoBalance_UnitScript::ModifyPeriodicDamageAurasTick(Unit* target, Unit* source, uint32& amount, SpellInfo const* spellInfo)
 {
@@ -253,8 +254,8 @@ int32 AutoBalance_UnitScript::_Modify_Damage_Healing(Unit* target, Unit* source,
     }
 
     // get the maps' info
-    AutoBalanceMapInfo* sourceMapABInfo = source->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
-    AutoBalanceMapInfo* targetMapABInfo = target->GetMap()->CustomData.GetDefault<AutoBalanceMapInfo>("AutoBalanceMapInfo");
+    AutoBalanceMapInfo* sourceMapABInfo = GetMapInfo(source->GetMap());
+    AutoBalanceMapInfo* targetMapABInfo = GetMapInfo(target->GetMap());
 
     // if either the target or the source's maps are not enabled, return the original damage
     if (!sourceMapABInfo->enabled || !targetMapABInfo->enabled)

--- a/src/ABUtils.cpp
+++ b/src/ABUtils.cpp
@@ -3007,6 +3007,7 @@ AutoBalanceMapInfo* GetMapInfo(Map* map)
         map->GetMapName(),
         map->GetId(),
         map->GetInstanceId() ? "-" + std::to_string(map->GetInstanceId()) : "");
+
     mapABInfo->initialized = true;
 
     if (!map->IsDungeon())

--- a/src/ABUtils.h
+++ b/src/ABUtils.h
@@ -9,6 +9,7 @@
 #include "ABLevelScalingDynamicLevelSettings.h"
 #include "ABStatModifiers.h"
 #include "AutoBalance.h"
+#include "ABMapInfo.h"
 
 #include "Creature.h"
 #include "Map.h"
@@ -58,5 +59,6 @@ void UpdateMapPlayerStats (Map* map);
 void AddPlayerToMap(Map* map, Player* player);
 bool RemovePlayerFromMap(Map* map, Player* player);
 bool UpdateMapDataIfNeeded(Map* map, bool force = false);
+AutoBalanceMapInfo* GetMapInfo(Map* map);
 
 #endif

--- a/src/ABUtils.h
+++ b/src/ABUtils.h
@@ -7,9 +7,9 @@
 
 #include "ABInflectionPointSettings.h"
 #include "ABLevelScalingDynamicLevelSettings.h"
+#include "ABMapInfo.h"
 #include "ABStatModifiers.h"
 #include "AutoBalance.h"
-#include "ABMapInfo.h"
 
 #include "Creature.h"
 #include "Map.h"


### PR DESCRIPTION
## Changes Proposed:

Level scaling is broken because the OnCreateMap is called after OnBeforeCreatureSelectLevel

This lead to lfg level information not being set when the map is created, and the level scaling logic is not able to find the lfg level information. This commit fixes that by moving the logic from OnCreateMap to a new function called GetMapInfo used in all the places where we need to get the autobalance map info. The first time the map is requested, it will be initialized and the data will be set.

<!-- First of all, THANK YOU for your contribution. -->


## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

None directly but I think some issues might be linked to the missing information as the MapInfo doesn't store any information about the creatures

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

Before patch

![image](https://github.com/user-attachments/assets/ad3b792c-2afd-4d01-a683-27c28a0e57b8)

After patch

![image](https://github.com/user-attachments/assets/8aebb829-c50c-4ae4-8f5a-bc6182979b5f)

## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Enable levelscaling
2. Enter an instance
3. Check `.ab mapstat` output
4. Check `SkipHigherLevels` and `SkipLowerLevels` configuration work as expected

