### PR TITLE
Add options to configure minimum players in raids

### DIFF
--- a/conf/AutoBalance.conf.dist
+++ b/conf/AutoBalance.conf.dist
@@ -81,6 +81,8 @@ AutoBalance.Disable.PerInstance = ""
 #        Default: 1
 AutoBalance.MinPlayers = 1
 AutoBalance.MinPlayers.Heroic = 1
+AutoBalance.MinPlayers.Raid = 1
+AutoBalance.MinPlayers.RaidHeroic = 1
 
 #
 #     AutoBalance.MinPlayers.PerInstance

--- a/src/ABConfig.cpp
+++ b/src/ABConfig.cpp
@@ -10,6 +10,8 @@ std::list<uint32> disabledDungeonIds;
 
 uint32 minPlayersNormal;
 uint32 minPlayersHeroic;
+uint32 minPlayersRaid;
+uint32 minPlayersRaidHeroic;
 std::map<uint32, uint8> minPlayersPerDungeonIdMap;
 std::map<uint32, uint8> minPlayersPerHeroicDungeonIdMap;
 

--- a/src/ABConfig.h
+++ b/src/ABConfig.h
@@ -28,7 +28,7 @@ extern std::list<uint32>                                             disabledDun
 
 extern uint32                                                        minPlayersNormal;
 extern uint32                                                        minPlayersHeroic;
-extern uint32                                                        minPlayersRaidNormal;
+extern uint32                                                        minPlayersRaid;
 extern uint32                                                        minPlayersRaidHeroic;
 extern std::map<uint32, uint8>                                       minPlayersPerDungeonIdMap;
 extern std::map<uint32, uint8>                                       minPlayersPerHeroicDungeonIdMap;

--- a/src/ABConfig.h
+++ b/src/ABConfig.h
@@ -28,6 +28,8 @@ extern std::list<uint32>                                             disabledDun
 
 extern uint32                                                        minPlayersNormal;
 extern uint32                                                        minPlayersHeroic;
+extern uint32                                                        minPlayersRaidNormal;
+extern uint32                                                        minPlayersRaidHeroic;
 extern std::map<uint32, uint8>                                       minPlayersPerDungeonIdMap;
 extern std::map<uint32, uint8>                                       minPlayersPerHeroicDungeonIdMap;
 

--- a/src/ABUtils.cpp
+++ b/src/ABUtils.cpp
@@ -2059,10 +2059,14 @@ void LoadMapSettings(Map* map)
 
     if (isDungeonInMinPlayerMap(map->GetId(), instanceMap->IsHeroic()))
         mapABInfo->minPlayers = instanceMap->IsHeroic() ? minPlayersPerHeroicDungeonIdMap[map->GetId()] : minPlayersPerDungeonIdMap[map->GetId()];
-    else if (instanceMap->IsHeroic())
-        mapABInfo->minPlayers = minPlayersHeroic;
-    else
+    if (instanceMap->GetMaxPlayers() <= 5 && !instanceMap->IsHeroic())
         mapABInfo->minPlayers = minPlayersNormal;
+    else if (instanceMap->GetMaxPlayers() <= 5 && instanceMap->IsHeroic())
+        mapABInfo->minPlayers = minPlayersHeroic;
+    else if (instanceMap->GetMaxPlayers() > 5 && !instanceMap->IsHeroic())
+        mapABInfo->minPlayers = minPlayersRaid;
+    else
+        mapABInfo->minPlayers = minPlayersRaidHeroic;
 
     //
     // If the minPlayers value we determined is less than the max number of players in this map, adjust down

--- a/src/ABWorldScript.cpp
+++ b/src/ABWorldScript.cpp
@@ -45,6 +45,8 @@ void AutoBalance_WorldScript::SetInitialWorldSettings()
 
     minPlayersNormal = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers", 1);
     minPlayersHeroic = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers.Heroic", 1);
+    minPlayersRaidNormal = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers.Raid", minPlayersNormal);
+    minPlayersRaidHeroic = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers.RaidHeroic", minPlayersHeroic);
 
     if (sConfigMgr->GetOption<float>("AutoBalance.PerDungeonPlayerCounts", false, false))
         LOG_WARN("server.loading", "mod-autobalance: deprecated value `AutoBalance.PerDungeonPlayerCounts` defined in `AutoBalance.conf`. This variable will be removed in a future release. Please see `AutoBalance.conf.dist` for more details.");

--- a/src/ABWorldScript.cpp
+++ b/src/ABWorldScript.cpp
@@ -45,7 +45,7 @@ void AutoBalance_WorldScript::SetInitialWorldSettings()
 
     minPlayersNormal = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers", 1);
     minPlayersHeroic = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers.Heroic", 1);
-    minPlayersRaidNormal = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers.Raid", minPlayersNormal);
+    minPlayersRaid = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers.Raid", minPlayersNormal);
     minPlayersRaidHeroic = sConfigMgr->GetOption<int>("AutoBalance.MinPlayers.RaidHeroic", minPlayersHeroic);
 
     if (sConfigMgr->GetOption<float>("AutoBalance.PerDungeonPlayerCounts", false, false))


### PR DESCRIPTION
<!-- First of all, THANK YOU for your contribution. -->

## Changes Proposed:

Add a configuration option to set the minimum players required for raid scaling. Independent of dungeons minimum players.

## Issues Addressed:
<!-- If your fix has a relating issue, link it below -->

/

## SOURCE:
<!-- If you can, include a source that can strengthen your claim -->

/

## Tests Performed:
<!-- Does it build without errors? Did you test in-game? What did you test? On which OS did you test? Describe any other tests performed -->

Test are WIP


## How to Test the Changes:
<!-- Describe in a detailed step-by-step order how to test the changes -->

1. Set a > 1 minimum players
2. Check applied scaling with `.ab mapstat` when under and over the limit
